### PR TITLE
Add town name to log messages

### DIFF
--- a/Bot/ACNHMobileSpawner/OffsetHelper.cs
+++ b/Bot/ACNHMobileSpawner/OffsetHelper.cs
@@ -30,6 +30,7 @@
         public const ulong LandMakingMapStart = FieldItemStart + 0xAAA00;
         public const ulong OutsideFieldStart = FieldItemStart + 0xCF998;
         public const ulong MainFieldStructurStart = FieldItemStart + 0xCF600;
+        public const ulong TownNameAddress = 0xABBDC2A4;
 
         // other addresses
         public const ulong ArriverNameLocAddress = 0xB66F4EE0;


### PR DESCRIPTION
Because users set up one bot to connect to multiple switches simultaneously, adding the island name to the log messages (for dodos, crashes, arrivals, and departures) will help them differentiate which island the messages are referring to. 