### PR TITLE
Various fixes, improvements and protocol changes 

### DIFF
--- a/Bot/SocketAPI/SocketAPIProtocol.cs
+++ b/Bot/SocketAPI/SocketAPIProtocol.cs
@@ -31,12 +31,14 @@ namespace SocketAPI
 
 		/// <summary>
 		/// Given the message type and input string, this method returns an encoded message ready to be sent to a client.
+		/// The JSON-encoded message is terminated by "\0\0".
+		/// Do not send messages of length > 2^16 bytes (or your OS's default TCP buffer size)! The messages would get TCP-fragmented.
 		/// </summary>
 		public static string? EncodeMessage(SocketAPIMessage message)
 		{
 			try
 			{
-				return JsonSerializer.Serialize(message);
+				return JsonSerializer.Serialize(message) + "\0\0";
 			}
 			catch (System.Exception ex)
 			{

--- a/Bot/SocketAPI/SocketAPIServer.cs
+++ b/Bot/SocketAPI/SocketAPIServer.cs
@@ -78,7 +78,16 @@ namespace SocketAPI {
 			Logger.LogInfo($"n. of registered endpoints: {eps}");
 
 			listener = new(IPAddress.Any, config.Port);
-			listener.Start();
+
+			try 
+			{
+				listener.Start();
+			}
+			catch(SocketException ex)
+			{
+				Logger.LogError($"Socket API server failed to start: {ex.Message}");
+				return;
+			}
 
 			Logger.LogInfo($"Socket API server listening on port {config.Port}.");
 

--- a/Program.cs
+++ b/Program.cs
@@ -74,9 +74,9 @@ namespace SysBot.ACNHOrders
 			SaveConfig(config, configPath);
             SaveConfig(twitchConfig, DefaultTwitchPath);
 			SaveConfig(serverConfig, DefaultSocketServerAPIPath);
-
-			SocketAPI.SocketAPIServer server = new();
-			_ = server.Start(serverConfig);
+            
+			SocketAPI.SocketAPIServer server = SocketAPI.SocketAPIServer.shared;
+			await server.Start(serverConfig);
 
 			await BotRunner.RunFrom(config, CancellationToken.None, twitchConfig).ConfigureAwait(false);
 


### PR DESCRIPTION
## Proposed changes

- Fixed an issue where a broken pipe to client could terminate the bot process
- Handled `TcpListener.Start()` exception, occurring when a user misconfigures the server
- Made `SocketAPIServer` a singleton. There is supposed to be a single instance of `SocketAPIServer` and its methods shall be accessed at global level
- `\0\0`-terminated JSON-formatted responses of all kinds, to handle TCP packets getting merged on the client side

I would like to add a README for the server! May I do so on the repo's root folder?

Thank you again! Hopefully no compile-time .net47 errors this time around 🤣